### PR TITLE
Update Swagger schema URL for python/ruby and clean up some whitespace

### DIFF
--- a/python/build.gradle
+++ b/python/build.gradle
@@ -19,10 +19,10 @@ task buildSempLib << {
     }
     def f = new File('../swagger.yaml')
     if (!f.exists()) {
-        new URL('https://sftp.solace.com/download/VMR_SEMPV2_SCHEMA_YAML').withInputStream{ i -> f.withOutputStream{ it << i }}
-    }       
+        new URL('https://products.solace.com/download/PUBSUB_SEMPV2_SCHEMA_YAML').withInputStream{ i -> f.withOutputStream{ it << i }}
+    }
     delete "workdir"; (new File("workdir")).mkdirs()
-    javaexec { 
+    javaexec {
         main="-jar";
         classpath configurations.tool
         workingDir = "workdir"
@@ -36,7 +36,7 @@ task buildSempLib << {
             "-c",
             "../codegen_config_python.json"
             ]
-    } 
+    }
     // Cleanup
     delete "workdir" + "/test"
     delete fileTree("workdir") {

--- a/ruby/build.gradle
+++ b/ruby/build.gradle
@@ -19,7 +19,7 @@ task buildSempLib << {
     }
     def f = new File('../swagger.yaml')
     if (!f.exists()) {
-        new URL('https://sftp.solace.com/download/VMR_SEMPV2_SCHEMA_YAML').withInputStream{ i -> f.withOutputStream{ it << i }}
+        new URL('https://products.solace.com/download/PUBSUB_SEMPV2_SCHEMA_YAML').withInputStream{ i -> f.withOutputStream{ it << i }}
     }
     delete "workdir"; (new File("workdir")).mkdirs()
     javaexec {

--- a/ruby/build.gradle
+++ b/ruby/build.gradle
@@ -20,9 +20,9 @@ task buildSempLib << {
     def f = new File('../swagger.yaml')
     if (!f.exists()) {
         new URL('https://sftp.solace.com/download/VMR_SEMPV2_SCHEMA_YAML').withInputStream{ i -> f.withOutputStream{ it << i }}
-    }       
+    }
     delete "workdir"; (new File("workdir")).mkdirs()
-    javaexec { 
+    javaexec {
         main="-jar";
         classpath configurations.tool
         workingDir = "workdir"
@@ -36,7 +36,7 @@ task buildSempLib << {
             "-c",
             "../codegen_config_ruby.json"
             ]
-    } 
+    }
     // Cleanup
     delete fileTree("workdir") {
         exclude "*.gemspec"


### PR DESCRIPTION
The current URL in `gradle.build` for ruby/python isn't valid. This PR updates it to the one in the `java` folder which works. 

